### PR TITLE
fix: add primary favicon.ico with Google's service as fallback

### DIFF
--- a/app/src/components/LinkPreview.jsx
+++ b/app/src/components/LinkPreview.jsx
@@ -1,5 +1,5 @@
   import React from "react";
-  import { getPrimaryFavicon, getGoogleFavicon } from "../utils/favicontjs";
+  import { getPrimaryFavicon, getGoogleFavicon } from "../utils/favicon.ts";
   
   const LinkPreview = ({ title, url, isVisible, onClick }) => {
     if (!isVisible) {

--- a/app/src/components/LinkPreview.jsx
+++ b/app/src/components/LinkPreview.jsx
@@ -1,9 +1,10 @@
-import React from "react";
-
-const LinkPreview = ({ title, iconUrl, url, isVisible, onClick }) => {
-  if (!isVisible) {
-    return null;
-  }
+  import React from "react";
+  import { getPrimaryFavicon, getGoogleFavicon } from "../utils/favicontjs";
+  
+  const LinkPreview = ({ title, url, isVisible, onClick }) => {
+    if (!isVisible) {
+      return null;
+    }
 
   // Sanitize and shorten the URL for display
   const displayUrl = url
@@ -15,20 +16,21 @@ const LinkPreview = ({ title, iconUrl, url, isVisible, onClick }) => {
       className="mt-3 bg-white rounded-lg shadow-md p-2 sm:p-3 w-full border border-gray-200 text-gray-800 cursor-pointer"
       onClick={onClick}
     >
-      <div className="flex items-center justify-between gap-2 sm:gap-3 w-full">
-        <div className="flex items-center min-w-0 flex-1">
-          {iconUrl && (
-            <img
-              src={iconUrl}
-              alt="Link Icon"
-              className="w-6 h-6 sm:w-8 sm:h-8 mr-1.5 sm:mr-2 flex-shrink-0"
-              onError={(e) => {
-                // Hide the broken image
-                e.target.style.display = "none";
-              }}
-            />
-          )}
-          <span className="text-xs sm:text-sm font-semibold truncate">
+        <div className="flex items-center justify-between gap-2 sm:gap-3 w-full">
+          <div className="flex items-center min-w-0 flex-1">
+            {(getPrimaryFavicon || getGoogleFavicon )  && (
+              <img
+                src={getPrimaryFavicon(url)}
+                onError={(e) => {
+                    e.currentTarget.onerror = null;
+                    e.currentTarget.src = getGoogleFavicon(url);
+                  }
+                }
+                alt="Link Icon"
+                className="w-6 h-6 sm:w-8 sm:h-8 mr-1.5 sm:mr-2 flex-shrink-0"
+              />
+            )}
+            <span className="text-xs sm:text-sm font-semibold truncate">
             {title || "No Title"}
           </span>
         </div>

--- a/app/src/components/SearchGlobal.jsx
+++ b/app/src/components/SearchGlobal.jsx
@@ -3,7 +3,7 @@ import { Search, X } from "lucide-react";
 import { db } from "../core/db/db";
 import { useLiveQuery } from "dexie-react-hooks";
 import { Command } from "lucide-react";
-import { getPrimaryFavicon, getGoogleFavicon } from "../utils/favicontjs";
+import { getPrimaryFavicon, getGoogleFavicon } from "../utils/favicon.ts";
 
 export default function SearchGlobal({ setSearchOpen }) {
   const inputRef = useRef(null);

--- a/app/src/components/SearchGlobal.jsx
+++ b/app/src/components/SearchGlobal.jsx
@@ -3,6 +3,7 @@ import { Search, X } from "lucide-react";
 import { db } from "../core/db/db";
 import { useLiveQuery } from "dexie-react-hooks";
 import { Command } from "lucide-react";
+import { getPrimaryFavicon, getGoogleFavicon } from "../utils/favicontjs";
 
 export default function SearchGlobal({ setSearchOpen }) {
   const inputRef = useRef(null);
@@ -90,23 +91,6 @@ export default function SearchGlobal({ setSearchOpen }) {
     setSearchQuery("");
   };
 
-  const getFaviconUrl = (url) => {
-    try {
-      // Normalize URL - add https:// if missing
-      let normalizedUrl = url;
-      if (!url.startsWith("http://") && !url.startsWith("https://")) {
-        normalizedUrl = `https://${url}`;
-      }
-      const domain = new URL(normalizedUrl).hostname;
-      return `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
-    } catch {
-      // Fallback: try to extract domain from string
-      const domainMatch = url.match(/(?:https?:\/\/)?(?:www\.)?([^\/]+)/);
-      const domain = domainMatch ? domainMatch[1] : url;
-      return `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
-    }
-  };
-
   return (
     <div
       className={`fixed inset-0 bg-black/60 backdrop-blur-sm flex flex-col items-center pt-16 sm:pt-28 z-50 transition-opacity duration-200 px-4 ${
@@ -180,12 +164,13 @@ export default function SearchGlobal({ setSearchOpen }) {
                   }`}
                 >
                   <img
-                    src={getFaviconUrl(link.url)}
+                    src={getPrimaryFavicon(link.url)}
+                    onError={(e) => {
+                      e.currentTarget.onerror = null;
+                      e.currentTarget.src = getGoogleFavicon(link.url);
+                    }}
                     className="w-6 h-6 sm:w-8 sm:h-8 flex-shrink-0 rounded"
                     alt=""
-                    onError={(e) => {
-                      e.target.style.display = "none";
-                    }}
                   />
                   <div className="flex-1 min-w-0">
                     <div className="font-medium text-xs sm:text-sm truncate">

--- a/app/src/components/Widgets.jsx
+++ b/app/src/components/Widgets.jsx
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from "uuid";
 import { db } from "../core/db/db";
 import { SettingsContext } from "../contexts/SettingsProvider.jsx";
 import LinkPreview from "./LinkPreview.jsx";
-import { getPrimaryFavicon, getGoogleFavicon } from "../utils/favicontjs";
+import { getPrimaryFavicon, getGoogleFavicon } from "../utils/favicon.ts";
 
 const Widget = ({ widget, widgets, setWidgets }) => {
   const [showAddLink, setShowAddLink] = useState(false);

--- a/app/src/components/Widgets.jsx
+++ b/app/src/components/Widgets.jsx
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from "uuid";
 import { db } from "../core/db/db";
 import { SettingsContext } from "../contexts/SettingsProvider.jsx";
 import LinkPreview from "./LinkPreview.jsx";
+import { getPrimaryFavicon, getGoogleFavicon } from "../utils/favicontjs";
 
 const Widget = ({ widget, widgets, setWidgets }) => {
   const [showAddLink, setShowAddLink] = useState(false);
@@ -564,10 +565,13 @@ const Widget = ({ widget, widgets, setWidgets }) => {
                       {/* Add this as a toggle in Settings */}
                       {/* <div className="w-6 h-6 rounded-full bg-white/10 flex items-center justify-center">*/}
                       <img
-                        src={`https://www.google.com/s2/favicons?domain=${l.url}&sz=32`}
+                        src={getPrimaryFavicon(l.url)}
+                        onError={(e) => {
+                          e.currentTarget.onerror = null;
+                          e.currentTarget.src = getGoogleFavicon(l.url);
+                        }}
                         className="w-4 h-4 flex-shrink-0 rounded"
                         alt=""
-                        onError={(e) => (e.target.style.display = "none")}
                       />
                       {/* </div>*/}
                       <a
@@ -671,7 +675,6 @@ const Widget = ({ widget, widgets, setWidgets }) => {
 
                 <LinkPreview
                   title={newLink.name}
-                  iconUrl={`https://www.google.com/s2/favicons?domain=${newLink.url}&sz=32`}
                   url={newLink.url}
                   isVisible={fetchedTitle}
                   onClick={() => addLink(widget.id)}

--- a/app/src/utils/favicon.ts
+++ b/app/src/utils/favicon.ts
@@ -1,0 +1,31 @@
+// Checks root domain for favicon.
+export function getPrimaryFavicon(url: string): string | null {
+  try {
+    let normalized = url;
+
+    if (!/^https?:\/\//i.test(url)) {
+      normalized = "https://" + url;
+    }
+
+    const { origin } = new URL(normalized);
+    return `${origin}/favicon.ico`;
+  } catch {
+    return null;
+  }
+}
+
+// Fallback method using google's S2 service to fetch a favicon.
+export function getGoogleFavicon(url: string): string {
+  try {
+    let normalized = url;
+
+    if (!/^https?:\/\//i.test(url)) {
+      normalized = "https://" + url;
+    }
+
+    const domain = new URL(normalized).hostname;
+    return `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
+  } catch {
+    return "";
+  }
+}


### PR DESCRIPTION
This PR improves favicon handling by first attempting to load the site’s root `/favicon.ico`.
If unavailable, falls back to Google’s favicon service for reliability.

TL;DR: 

Priority Order
1. Root Domain `/favicon.ico`
2. Google favicon service (fallback)

Fixes: #1 